### PR TITLE
Updated Parser to interpret rem marker

### DIFF
--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -46,7 +46,8 @@ namespace USFMToolsSharp
             List<string> unkownMarkers = new List<string>();
             foreach(UnknownMarker marker in findUnknown)
             {
-                unkownMarkers.Add(marker.ParsedIdentifier);
+                if(!unkownMarkers.Contains(marker.ParsedIdentifier))
+                    unkownMarkers.Add(marker.ParsedIdentifier);
             }
 
             return output;
@@ -131,6 +132,8 @@ namespace USFMToolsSharp
                     return new ITMarker();
                 case "it*":
                     return new ITEndMarker();
+                case "rem":
+                    return new REMMarker();
                 default:
                     return new UnknownMarker() { ParsedIdentifier = identifier };
             }

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -42,13 +42,6 @@ namespace USFMToolsSharp
                     output.Insert(new TextBlock(result.remainingText));
                 }
             }
-            List<UnknownMarker> findUnknown = output.GetChildMarkers<UnknownMarker>();
-            List<string> unkownMarkers = new List<string>();
-            foreach(UnknownMarker marker in findUnknown)
-            {
-                if(!unkownMarkers.Contains(marker.ParsedIdentifier))
-                    unkownMarkers.Add(marker.ParsedIdentifier);
-            }
 
             return output;
         }

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -42,6 +42,12 @@ namespace USFMToolsSharp
                     output.Insert(new TextBlock(result.remainingText));
                 }
             }
+            List<UnknownMarker> findUnknown = output.GetChildMarkers<UnknownMarker>();
+            List<string> unkownMarkers = new List<string>();
+            foreach(UnknownMarker marker in findUnknown)
+            {
+                unkownMarkers.Add(marker.ParsedIdentifier);
+            }
 
             return output;
         }


### PR DESCRIPTION
Marker content is not for publication, therefore needs no rendering. (Unless otherwise stated)