### PR TITLE
update AllowedContents; fixed typos

### DIFF
--- a/USFMToolsSharp/HtmlRenderer.cs
+++ b/USFMToolsSharp/HtmlRenderer.cs
@@ -124,6 +124,7 @@ namespace USFMToolsSharp
                     if (ConfigurationHTML.separateChapters)
                     {
                         output.AppendLine("<br class=\"pagebreak\"></br>");
+                        output.AppendLine("<div class=\"pagebreak\"></div>");
                     }
 
                     break;
@@ -185,6 +186,7 @@ namespace USFMToolsSharp
                     if (!ConfigurationHTML.separateChapters && mTMarker.Weight==1)   // No double page breaks before books
                     {
                         output.AppendLine("<br class=\"pagebreak\"></br>");
+                        output.AppendLine("<div class=\"pagebreak\"></div>");
                     }
                     break;
                 case MSMarker mSMarker:

--- a/USFMToolsSharp/Models/Markers/FKMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FKMarker.cs
@@ -7,7 +7,7 @@ namespace USFMToolsSharp.Models.Markers
     /// <summary>
     /// Footnote keyword Marker
     /// </summary>
-    class FKMarker : Marker
+    public class FKMarker : Marker
     {
         public override string Identifier => "fk";
         public string FootNoteKeyword;

--- a/USFMToolsSharp/Models/Markers/FMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FMarker.cs
@@ -30,6 +30,10 @@ namespace USFMToolsSharp.Models.Markers
             typeof(FQAEndMarker),
             typeof(FQMarker),
             typeof(FQEndMarker),
+            typeof(TLMarker),
+            typeof(TLEndMarker),
+            typeof(WMarker),
+            typeof(WEndMarker),
             typeof(TextBlock),
         };
     }

--- a/USFMToolsSharp/Models/Markers/FQAMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQAMarker.cs
@@ -14,6 +14,10 @@ namespace USFMToolsSharp.Models.Markers
         public override List<Type> AllowedContents => new List<Type>()
         {
             typeof(TextBlock),
+            typeof(TLMarker),
+            typeof(TLEndMarker),
+            typeof(WMarker),
+            typeof(WEndMarker),
         };
     }
 }

--- a/USFMToolsSharp/Models/Markers/FQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQMarker.cs
@@ -14,6 +14,10 @@ namespace USFMToolsSharp.Models.Markers
         public override List<Type> AllowedContents => new List<Type>()
         {
             typeof(TextBlock),
+            typeof(TLMarker),
+            typeof(TLEndMarker),
+            typeof(WMarker),
+            typeof(WEndMarker),
         };
     }
 }

--- a/USFMToolsSharp/Models/Markers/FRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FRMarker.cs
@@ -7,7 +7,7 @@ namespace USFMToolsSharp.Models.Markers
     /// <summary>
     /// Footnote origin reference
     /// </summary>
-    class FRMarker : Marker
+    public class FRMarker : Marker
     {
         public override string Identifier => "fr";
         public string VerseReference;

--- a/USFMToolsSharp/Models/Markers/FTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FTMarker.cs
@@ -12,6 +12,8 @@ namespace USFMToolsSharp.Models.Markers
             typeof(FQMarker),
             typeof(TLMarker),
             typeof(TLEndMarker),
+            typeof(WMarker),
+            typeof(WEndMarker),
             typeof(TextBlock),
         };
     }

--- a/USFMToolsSharp/Models/Markers/LIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/LIMarker.cs
@@ -10,12 +10,7 @@ namespace USFMToolsSharp.Models.Markers
     public class LIMarker : Marker
     {
         public int Depth = 1;
-        public string Text;
         public override string Identifier => "li";
-        public override string PreProcess(string input)
-        {
-            return string.Empty;
-        }
         public override List<Type> AllowedContents => new List<Type>() {
             typeof(VMarker),
             typeof(TextBlock)

--- a/USFMToolsSharp/Models/Markers/PMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PMarker.cs
@@ -15,7 +15,8 @@ namespace USFMToolsSharp.Models.Markers
             typeof(FMarker),
             typeof(FEndMarker),
             typeof(PIMarker),
-            typeof(LIMarker)
+            typeof(LIMarker),
+            typeof(QMarker)
         };
     }
 }

--- a/USFMToolsSharp/Models/Markers/QMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QMarker.cs
@@ -12,18 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public int Depth = 1;
         public string Text;
         public override string Identifier => "q";
-        public override List<Type> AllowedContents
-        {
-            get
-            {
-                return new List<Type>()
-                {
-                    typeof(VMarker),
-                    typeof(BMarker),
-                    typeof(QSMarker),
-                    typeof(TextBlock),
-                };
-            }
-        }
+        public override List<Type> AllowedContents => new List<Type>() {
+            typeof(BMarker),
+            typeof(QSMarker),
+            typeof(TextBlock),
+        };
     }
 }

--- a/USFMToolsSharp/Models/Markers/VMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VMarker.cs
@@ -36,7 +36,6 @@ namespace USFMToolsSharp.Models.Markers
                 {
                     typeof(VPMarker),
                     typeof(VPEndMarker),
-                    typeof(TRMarker),
                     typeof(TLMarker),
                     typeof(TLEndMarker),
                     typeof(ADDMarker),

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -248,11 +248,11 @@ namespace USFMToolsSharp
                 case "tcr1":
                     return new TCRMarker();
                 case "tc2":
-                    return new THMarker() { ColumnPosition = 2 };
+                    return new TCMarker() { ColumnPosition = 2 };
                 case "tcr2":
                     return new TCRMarker() { ColumnPosition = 2 };
                 case "tc3":
-                    return new THMarker() { ColumnPosition = 3 };
+                    return new TCMarker() { ColumnPosition = 3 };
                 case "tcr3":
                     return new TCRMarker() { ColumnPosition = 3 };
 


### PR DESCRIPTION
The set of pagebreaks are intentional, but shouldn't stay there for long. I didn't want to break any features that are implemented currently. Once we build a DocxRenderer, I'll remove one of them.

`output.AppendLine("<br class=\"pagebreak\"></br>");` page breaks in Microsoft Word (exclusively)
`output.AppendLine("<div class=\"pagebreak\"></div>");` page breaks in Browsers (exclusively) 