### PR TITLE
Additional Fixes for QMarkers

### DIFF
--- a/USFMToolsSharp/Models/Markers/QMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QMarker.cs
@@ -12,6 +12,7 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int Depth = 1;
         public string Text;
+        public bool IsPoetryBlock;
         public override string Identifier => "q";
         public override string PreProcess(string input)
         {

--- a/USFMToolsSharp/Models/Markers/VMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VMarker.cs
@@ -99,6 +99,12 @@ namespace USFMToolsSharp.Models.Markers
             {
                 return false;
             }
+
+            if (input is QMarker poetryMarker && poetryMarker.IsPoetryBlock)
+            {
+                return false;
+            }
+
             return base.TryInsert(input);
         }
     }

--- a/USFMToolsSharp/Models/Markers/VMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VMarker.cs
@@ -93,5 +93,13 @@ namespace USFMToolsSharp.Models.Markers
                     typeof(VAMarker),
                     typeof(VAEndMarker)
                 };
+        public override bool TryInsert(Marker input)
+        {
+            if (input is VMarker)
+            {
+                return false;
+            }
+            return base.TryInsert(input);
+        }
     }
 }

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -12,6 +12,7 @@ namespace USFMToolsSharp
     public class USFMParser
     {
         private readonly List<string> IgnoredTags;
+        private static Regex splitRegex = new Regex("\\\\([a-z0-9\\-]*\\**)([^\\\\]*)");
 
         public USFMParser()
         {
@@ -25,33 +26,44 @@ namespace USFMToolsSharp
 
         public USFMDocument ParseFromString(string input)
         {
-            Regex splitRegex = new Regex("\\\\([a-z0-9\\-]*\\**)([^\\\\]*)");
             USFMDocument output = new USFMDocument();
+            var markers = TokenizeFromString(input);
 
-            foreach(Match match in splitRegex.Matches(input))
+            foreach(Marker marker in markers)
             {
-                if(IgnoredTags.Contains(match.Groups[1].Value))
-                {
-                    continue;
-                }
-
-                ConvertToMarkerResult result = ConvertToMarker(match.Groups[1].Value, match.Groups[2].Value);
-                result.marker.Position = match.Index;
-
-                if(result.marker is TRMarker && !output.GetTypesPathToLastMarker().Contains(typeof(TableBlock)))
+                if(marker is TRMarker && !output.GetTypesPathToLastMarker().Contains(typeof(TableBlock)))
                 {
                     output.Insert(new TableBlock());
                 }
 
+                if(marker is QMarker && markers[markers.IndexOf(marker) + 1] is VMarker)
+                {
+                    ((QMarker)marker).IsPoetryBlock = true;
+                }
                 
-                output.Insert(result.marker);
+                output.Insert(marker);
+            }
+
+            return output;
+        }
+        private List<Marker> TokenizeFromString(string input)
+        {
+            List<Marker> output = new List<Marker>();
+
+            foreach(Match match in splitRegex.Matches(input))
+            {
+                if (IgnoredTags.Contains(match.Groups[1].Value))
+                {
+                    continue;
+                }
+                ConvertToMarkerResult result = ConvertToMarker(match.Groups[1].Value, match.Groups[2].Value);
+                result.marker.Position = match.Index;
+                output.Add(result.marker);
 
                 if (!string.IsNullOrWhiteSpace(result.remainingText))
                 {
-                    output.Insert(new TextBlock(result.remainingText));
+                    output.Add(new TextBlock(result.remainingText));
                 }
-                
-
             }
 
             return output;

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -24,6 +24,11 @@ namespace USFMToolsSharp
             IgnoredTags = tagsToIgnore;
         }
 
+        /// <summary>
+        /// Parses a string into a USFMDocument
+        /// </summary>
+        /// <param name="input">A USFM string</param>
+        /// <returns>A USFMDocument representing the input</returns>
         public USFMDocument ParseFromString(string input)
         {
             USFMDocument output = new USFMDocument();
@@ -46,6 +51,12 @@ namespace USFMToolsSharp
 
             return output;
         }
+
+        /// <summary>
+        /// Generate a list of Markers from a string
+        /// </summary>
+        /// <param name="input">USFM String to tokenize</param>
+        /// <returns>A List of Markers based upon the string</returns>
         private List<Marker> TokenizeFromString(string input)
         {
             List<Marker> output = new List<Marker>();

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -479,6 +479,9 @@ namespace USFMToolsSharpTest
             Assert.AreEqual(otherVerseText, ((TextBlock)output.Contents[0].Contents[3]).Text);
         }
 
+        /// <summary>
+        /// Verify that QMarker and VMarker nesting is handeld correctly
+        /// </summary>
         [TestMethod]
         public void TestVersePoetryNesting()
         {
@@ -489,7 +492,30 @@ namespace USFMToolsSharpTest
             Assert.IsTrue(output.Contents[0].Contents[0] is VMarker);
             Assert.IsTrue(output.Contents[0].Contents[0].Contents[1] is QMarker);
             Assert.IsTrue(output.Contents[1] is VMarker);
+
+            string secondVerseText = "\\v 1 This is verse one \\q another poetry \\v 2 second verse";
+
+            output = parser.ParseFromString(secondVerseText);
+            Assert.AreEqual(2, output.Contents.Count);
+            Assert.IsTrue(output.Contents[0] is VMarker);
+            Assert.IsTrue(output.Contents[0].Contents[1] is QMarker);
+            Assert.IsTrue(output.Contents[1] is VMarker);
         }
+
+        /// <summary>
+        /// Verify that an empty QMarker gets pushed back out to being a block QMarker
+        /// </summary>
+        [TestMethod]
+        public void TestEmptyQMarkerInVerse()
+        {
+            string verseText = "\\v 1 This is verse one \\q \\v 2 second verse";
+            var output = parser.ParseFromString(verseText);
+            Assert.AreEqual(2, output.Contents.Count);
+            Assert.IsTrue(output.Contents[0] is VMarker);
+            Assert.IsTrue(output.Contents[1] is QMarker);
+            Assert.IsTrue(output.Contents[1].Contents[0] is VMarker);
+        }
+
         [TestMethod]
         public void TestBadChapterHandling()
         {

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -512,7 +512,7 @@ namespace USFMToolsSharpTest
             var output = parser.ParseFromString(verseText);
             Assert.AreEqual(2, output.Contents.Count);
             Assert.IsTrue(output.Contents[0] is VMarker);
-            Assert.IsTrue(output.Contents[1] is QMarker);
+            Assert.IsTrue(output.Contents[1] is QMarker qMarker && qMarker.IsPoetryBlock);
             Assert.IsTrue(output.Contents[1].Contents[0] is VMarker);
         }
 


### PR DESCRIPTION
- Fixes an issue where a QMarker that was meant to be the parent for the next verse ends up being tacked on the end of the current verse
- Fixes an issue where a VMarker could get inserted in another
- Internally disconnected the lexing/tokenization function from building the AST