### PR TITLE
fix for missing parser tag

### DIFF
--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -269,6 +269,8 @@ namespace USFMToolsSharp
                     return new FTMarker();
                 case "fr":
                     return new FRMarker();
+                case "fr*":
+                    return new FREndMarker();
                 case "fk":
                     return new FKMarker();
                 case "fv":


### PR DESCRIPTION
the end marker for the fr tag is missing from the parser list