### PR TITLE
Fix for missing \fq* end marker and added in new markers: \fig \pn \pro

### DIFF
--- a/USFMToolsSharp/Models/Markers/FIGEndMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FIGEndMarker.cs
@@ -1,0 +1,10 @@
+﻿namespace USFMToolsSharp.Models.Markers
+{
+    /// <summary>
+    /// Footnote translations
+    /// </summary>
+    public class FIGEndMarker : Marker
+    {
+        public override string Identifier => "fig*";
+    }
+}

--- a/USFMToolsSharp/Models/Markers/FIGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FIGMarker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace USFMToolsSharp.Models.Markers
@@ -26,35 +27,74 @@ namespace USFMToolsSharp.Models.Markers
             string[] wordEntry = input.Split('|');
             if (wordEntry.Length > 0)
             {
-                Caption = wordEntry[0];
+                Description = wordEntry[0].Trim();
             }
             if (wordEntry.Length > 1)
             {
-                Description = wordEntry[1];
+                FilePath = wordEntry[1].Trim();
             }
             if (wordEntry.Length > 2)
             {
-                Width = wordEntry[2];
+                Width = wordEntry[2].Trim();
             }
             if (wordEntry.Length > 3)
             {
-                Location = wordEntry[3];
+                Location = wordEntry[3].Trim();
             }
             if (wordEntry.Length > 4)
             {
-                Copyright = wordEntry[4];
+                Copyright = wordEntry[4].Trim();
             }
             if (wordEntry.Length > 5)
             {
-                Reference = wordEntry[5];
+               Caption = wordEntry[5].Trim();
             }
             if (wordEntry.Length > 6)
             {
-                FilePath = wordEntry[6];
+                Reference = wordEntry[6].Trim();
             }
 
 
+            
+            string[] contentArr = input.Split('|');
+            if (contentArr.Length > 0 && contentArr.Length <= 2)
+            {
+                Caption = contentArr[0].Trim();
+
+                string[] attributes = contentArr[1].Split('"');
+                for (int i = 0; i < attributes.Length; i++)
+                {
+                    if (attributes[i].Replace(" ", "").Contains("alt="))
+                    {
+                        Description = attributes[i + 1].Trim();
+                    }
+                    if (attributes[i].Replace(" ", "").Contains("src="))
+                    {
+                        FilePath = attributes[i + 1].Trim();
+                    }
+                    if (attributes[i].Replace(" ", "").Contains("size="))
+                    {
+                        Width = attributes[i + 1].Trim();
+                    }
+                    if (attributes[i].Replace(" ", "").Contains("loc="))
+                    {
+                        Location = attributes[i + 1].Trim();
+                    }
+                    if (attributes[i].Replace(" ", "").Contains("copy="))
+                    {
+                        Copyright = attributes[i + 1].Trim();
+                    }
+                    if (attributes[i].Replace(" ", "").Contains("ref="))
+                    {
+                        Reference = attributes[i + 1].Trim();
+                    }
+                }
+            }
+
+            
+
             return string.Empty;
+            
         }
 
     }

--- a/USFMToolsSharp/Models/Markers/FIGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FIGMarker.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace USFMToolsSharp.Models.Markers
+{
+
+    /// <summary>
+    /// Wordlist / Glossary / Dictionary Entry Marker
+    /// </summary>
+    public class FIGMarker : Marker
+    {
+        public string Caption;
+        public string Description;
+        public string Width;
+        public string Location;
+        public string Copyright;
+        public string Reference;
+        public string FilePath;
+
+        public override string Identifier => "fig";
+
+        public override string PreProcess(string input)
+        {
+            input = input.Trim();
+
+            string[] wordEntry = input.Split('|');
+            if (wordEntry.Length > 0)
+            {
+                Caption = wordEntry[0];
+            }
+            if (wordEntry.Length > 1)
+            {
+                Description = wordEntry[1];
+            }
+            if (wordEntry.Length > 2)
+            {
+                Width = wordEntry[2];
+            }
+            if (wordEntry.Length > 3)
+            {
+                Location = wordEntry[3];
+            }
+            if (wordEntry.Length > 4)
+            {
+                Copyright = wordEntry[4];
+            }
+            if (wordEntry.Length > 5)
+            {
+                Reference = wordEntry[5];
+            }
+            if (wordEntry.Length > 6)
+            {
+                FilePath = wordEntry[6];
+            }
+
+
+            return string.Empty;
+        }
+
+    }
+}

--- a/USFMToolsSharp/Models/Markers/FMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FMarker.cs
@@ -30,6 +30,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(FQAMarker),
             typeof(FQAEndMarker),
             typeof(FQMarker),
+            typeof(FQEndMarker),
             typeof(TLMarker),
             typeof(TLEndMarker),
             typeof(WMarker),

--- a/USFMToolsSharp/Models/Markers/FQEndMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQEndMarker.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace USFMToolsSharp.Models.Markers
+{
+    /// <summary>
+    /// Footnote translations
+    /// </summary>
+    public class FQEndMarker : Marker
+    {
+        public override string Identifier => "fq*";
+    }
+}

--- a/USFMToolsSharp/Models/Markers/FQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQMarker.cs
@@ -23,7 +23,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(TLEndMarker),
             typeof(WMarker),
             typeof(WEndMarker),
-            typeof(FQEndMarker),
         };
     }
 }

--- a/USFMToolsSharp/Models/Markers/FQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQMarker.cs
@@ -23,6 +23,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(TLEndMarker),
             typeof(WMarker),
             typeof(WEndMarker),
+            typeof(FQEndMarker),
         };
     }
 }

--- a/USFMToolsSharp/Models/Markers/PNEndMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PNEndMarker.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace USFMToolsSharp.Models.Markers
+{
+    public class PNEndMarker : Marker
+    {
+        public override string Identifier => "pn*";
+    }
+}

--- a/USFMToolsSharp/Models/Markers/PNMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PNMarker.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace USFMToolsSharp.Models.Markers
+{
+    /// <summary>
+    /// Name of God (name of Deity)
+    /// </summary>
+    public class PNMarker : Marker
+    {
+        public override string Identifier => "pn";
+        public override string PreProcess(string input)
+        {
+            return input.Trim();
+        }
+        public override List<Type> AllowedContents => new List<Type>() {
+            typeof(TextBlock)
+        };
+    }
+}

--- a/USFMToolsSharp/Models/Markers/PROEndMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PROEndMarker.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace USFMToolsSharp.Models.Markers
+{
+    public class PROEndMarker : Marker
+    {
+        public override string Identifier => "pro*";
+    }
+}

--- a/USFMToolsSharp/Models/Markers/PROMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PROMarker.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace USFMToolsSharp.Models.Markers
+{
+    /// <summary>
+    /// Name of God (name of Deity)
+    /// </summary>
+    public class PROMarker : Marker
+    {
+        public override string Identifier => "pro";
+        public override string PreProcess(string input)
+        {
+            return input.Trim();
+        }
+        public override List<Type> AllowedContents => new List<Type>() {
+            typeof(TextBlock)
+        };
+    }
+}

--- a/USFMToolsSharp/Models/Markers/VMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VMarker.cs
@@ -91,7 +91,9 @@ namespace USFMToolsSharp.Models.Markers
                     typeof(QACEndMarker),
                     typeof(SMarker),
                     typeof(VAMarker),
-                    typeof(VAEndMarker)
+                    typeof(VAEndMarker),
+                    typeof(FIGMarker),
+                    typeof(FIGEndMarker),
                 };
         public override bool TryInsert(Marker input)
         {

--- a/USFMToolsSharp/Models/Markers/VMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VMarker.cs
@@ -94,6 +94,10 @@ namespace USFMToolsSharp.Models.Markers
                     typeof(VAEndMarker),
                     typeof(FIGMarker),
                     typeof(FIGEndMarker),
+                    typeof(PNMarker),
+                    typeof(PNEndMarker),
+                    typeof(PROMarker),
+                    typeof(PROEndMarker),
                 };
         public override bool TryInsert(Marker input)
         {

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -74,11 +74,6 @@ namespace USFMToolsSharp
                 result.marker.Position = match.Index;
                 output.Add(result.marker);
 
-                if (result.marker is UnknownMarker)
-                {
-                    Debug.WriteLine("UNK");
-                }
-
                 if (!string.IsNullOrWhiteSpace(result.remainingText))
                 {
                     output.Add(new TextBlock(result.remainingText));

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -401,6 +401,15 @@ namespace USFMToolsSharp
                     return new SUPEndMarker();
                 case "ie":
                     return new IEMarker();
+                case "pn":
+                    return new PNMarker();
+                case "pn*":
+                    return new PNEndMarker();
+                case "pro":
+                    return new PROMarker();
+                case "pro*":
+                    return new PROEndMarker();
+
 
                 /* Special Features */
                 case "fig":

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -269,6 +269,8 @@ namespace USFMToolsSharp
                     return new FTMarker();
                 case "fr":
                     return new FRMarker();
+                case "fr*":
+                    return new FREndMarker();
                 case "fk":
                     return new FKMarker();
                 case "fv":

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using USFMToolsSharp.Models;
 using USFMToolsSharp.Models.Markers;
@@ -72,6 +73,11 @@ namespace USFMToolsSharp
                 ConvertToMarkerResult result = ConvertToMarker(match.Groups[1].Value, match.Groups[2].Value);
                 result.marker.Position = match.Index;
                 output.Add(result.marker);
+
+                if (result.marker is UnknownMarker)
+                {
+                    Debug.WriteLine("UNK");
+                }
 
                 if (!string.IsNullOrWhiteSpace(result.remainingText))
                 {
@@ -256,6 +262,8 @@ namespace USFMToolsSharp
                     return new FQAEndMarker();
                 case "fq":
                     return new FQMarker();
+                case "fq*":
+                    return new FQEndMarker();
                 case "pi":
                 case "pi1":
                     return new PIMarker();
@@ -398,6 +406,13 @@ namespace USFMToolsSharp
                     return new SUPEndMarker();
                 case "ie":
                     return new IEMarker();
+
+                /* Special Features */
+                case "fig":
+                    return new FIGMarker();
+                case "fig*":
+                    return new FIGEndMarker();
+
                 default:
                     return new UnknownMarker() { ParsedIdentifier = identifier };
             }

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using USFMToolsSharp.Models;
 using USFMToolsSharp.Models.Markers;

--- a/USFMToolsSharp/USFMToolsSharp.csproj
+++ b/USFMToolsSharp/USFMToolsSharp.csproj
@@ -12,6 +12,7 @@
     <Authors>@rbnswartz</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Description>A parsing library for USFM</Description>
+    <Configurations>Debug;Release;PARATEXT;USFM_LOCAL</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/USFMToolsSharp/USFMToolsSharp.csproj
+++ b/USFMToolsSharp/USFMToolsSharp.csproj
@@ -12,7 +12,7 @@
     <Authors>@rbnswartz</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Description>A parsing library for USFM</Description>
-    <Configurations>Debug;Release;PARATEXT;USFM_LOCAL</Configurations>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -593,5 +593,76 @@ with a newline";
             Assert.AreEqual(verseText, ((TextBlock)output.Contents[0].Contents[0]).Text);
         }
 
+        [TestMethod]
+        public void TestFigureParse()
+        {
+            //PRE 3.0 TESTS
+            //Description;
+            Assert.AreEqual("description", ((FIGMarker)parser.ParseFromString
+            ("\\fig description|filepath|width|location|copyright|caption caption caption|reference\\fig*").Contents[0]).Description);
+            //FilePath;
+            Assert.AreEqual("filepath", ((FIGMarker)parser.ParseFromString
+            ("\\fig description| filepath|width|location|copyright|caption caption caption|reference\\fig*").Contents[0]).FilePath);
+            //Width;
+            Assert.AreEqual("width", ((FIGMarker)parser.ParseFromString
+            ("\\fig description|filepath |width|location|copyright|caption caption caption|reference\\fig*").Contents[0]).Width);
+            //Location;
+            Assert.AreEqual("location", ((FIGMarker)parser.ParseFromString
+            ("\\fig description|filepath|width | location|copyright|caption caption caption|reference\\fig*").Contents[0]).Location);
+            //Copyright;
+            Assert.AreEqual("copyright", ((FIGMarker)parser.ParseFromString
+            ("\\fig description|filepath|width|location|copyright |caption caption caption|reference\\fig*").Contents[0]).Copyright);
+            //Caption;
+            Assert.AreEqual("caption caption caption", ((FIGMarker)parser.ParseFromString
+            ("\\fig description|filepath|width|location|copyright|caption caption caption|reference\\fig*").Contents[0]).Caption);
+            //Reference;
+            Assert.AreEqual("reference", ((FIGMarker)parser.ParseFromString
+            ("\\fig description|filepath|width|location|copyright|caption caption caption | reference\\fig*").Contents[0]).Reference);
+
+            //3.0 TESTS
+            //Caption;
+            Assert.AreEqual("caption caption caption", ((FIGMarker)parser.ParseFromString
+                ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+                 "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).Caption);
+            //Description;
+            Assert.AreEqual("description", ((FIGMarker)parser.ParseFromString
+            ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+             "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).Description);
+            //FilePath;
+            Assert.AreEqual("filepath", ((FIGMarker)parser.ParseFromString
+            ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+             "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).FilePath);
+            //Width;
+            Assert.AreEqual("width", ((FIGMarker)parser.ParseFromString
+            ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+             "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).Width);
+            //Location;
+            Assert.AreEqual("location", ((FIGMarker)parser.ParseFromString
+            ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+             "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).Location);
+            //Copyright;
+            Assert.AreEqual("copyright", ((FIGMarker)parser.ParseFromString
+            ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+             "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).Copyright);
+            //Reference;
+            Assert.AreEqual("reference", ((FIGMarker)parser.ParseFromString
+            ("\\fig caption caption caption | alt=\"description\" src=\"filepath\" size=\"width\" loc =\"location\" " +
+             "copy= \"copyright\"  ref = \"reference\"\\fig*").Contents[0]).Reference);
+            
+
+
+            // Cross Reference Caller
+            Assert.AreEqual("-", ((XMarker)parser.ParseFromString("\\x - \\xo 11.21 \\xq Tebes \\xt \\x*").Contents[0]).CrossRefCaller);
+
+            // Cross Reference Origin
+            Assert.AreEqual("11.21", ((XOMarker)parser.ParseFromString("\\x - \\xo 11.21 \\xq Tebes \\xt \\x*").Contents[0].Contents[0]).OriginRef);
+
+            // Cross Reference Target
+            Assert.AreEqual("Mrk 1.24; Luk 2.39; Jhn 1.45.", ((TextBlock)parser.ParseFromString("\\x - \\xo 11.21 \\xq Tebes \\xt Mrk 1.24; Luk 2.39; Jhn 1.45.\\x*").Contents[0].Contents[2].Contents[0]).Text);
+
+            // Cross Reference Quotation
+            Assert.AreEqual("Tebes", ((TextBlock)parser.ParseFromString("\\x - \\xo 11.21 \\xq Tebes \\xt \\x*").Contents[0].Contents[1].Contents[0]).Text);
+        }
+
     }
 }


### PR DESCRIPTION
@rbnswartz if you can think of a better way to do the check on the `wordEntry` length on the FIGMarker.cs file to ensure that all those fields are there, I'd be interested in another method.