### PR TITLE
Parse User Defined Attributes in WMarker.cs

### DIFF
--- a/USFMToolsSharp/Models/Markers/WMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WMarker.cs
@@ -12,7 +12,7 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string Term;
         public Dictionary<string, string> Attributes;
-        private static Regex wordAttrPattern = new Regex("([\\w]+)=?\"?([\\w,:.]*)\"?", RegexOptions.Singleline);
+        private static Regex wordAttrPattern = new Regex("([\\w-]+)=?\"?([\\w,:.]*)\"?", RegexOptions.Singleline);
         public override string Identifier => "w";
 
         public override string PreProcess(string input)

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -399,6 +399,7 @@ namespace USFMToolsSharpTest
             Assert.AreEqual("G5485", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" strong=\"G5485\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["strong"]);
             Assert.AreEqual("H1234,G5485", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|strong=\"H1234,G5485\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["strong"]);
             Assert.AreEqual("gnt5:51.1.2.1", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" srcloc=\"gnt5:51.1.2.1\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["srcloc"]);
+            Assert.AreEqual("metadata", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" x-myattr="metadata" srcloc=\"gnt5:51.1.2.1\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["x-myattr"]);
 
         }
         [TestMethod]

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -399,7 +399,7 @@ namespace USFMToolsSharpTest
             Assert.AreEqual("G5485", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" strong=\"G5485\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["strong"]);
             Assert.AreEqual("H1234,G5485", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|strong=\"H1234,G5485\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["strong"]);
             Assert.AreEqual("gnt5:51.1.2.1", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" srcloc=\"gnt5:51.1.2.1\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["srcloc"]);
-            Assert.AreEqual("metadata", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" x-myattr="metadata" srcloc=\"gnt5:51.1.2.1\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["x-myattr"]);
+            Assert.AreEqual("metadata", ((WMarker)parser.ParseFromString("\\f + \\fr 3:5 \\fk berhala \\ft Lih. \\w gracious|lemma=\"grace\" x-myattr=\"metadata\" srcloc=\"gnt5:51.1.2.1\" \\w* di Daftar Istilah.\\f*").Contents[0].Contents[2].Contents[1]).Attributes["x-myattr"]);
 
         }
         [TestMethod]


### PR DESCRIPTION
As per the USFM Documentation:
https://ubsicap.github.io/usfm/attributes/index.html#user-defined-attributes

> Any user defined attributes must begin with the prefix x-.