### PR TITLE
Return WMarker Term from preprocess

### DIFF
--- a/USFMToolsSharp/Models/Markers/WMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WMarker.cs
@@ -43,7 +43,7 @@ namespace USFMToolsSharp.Models.Markers
 
             }
 
-            return string.Empty;
+            return Term;
         }
 
     }


### PR DESCRIPTION
Returning Term from preprocess allows for the word within a WMarker to be left as remaining text, which will then get picked up into a TextBlock. 

If this is not done, the word within a WMarker would be ignored when doing something such as getting all TextBlocks from a VMarker, which seems a sensible way to get scripture text without markup from a verse.