### PR TITLE
Optimizations

### DIFF
--- a/USFMToolsSharp/Models/ConvertToMarkerResult.cs
+++ b/USFMToolsSharp/Models/ConvertToMarkerResult.cs
@@ -8,14 +8,14 @@ namespace USFMToolsSharp.Models
     /// <summary>
     /// A holder class to take the place of a tuple
     /// </summary>
-    class ConvertToMarkerResult
+    ref struct ConvertToMarkerResult
     {
-        public ConvertToMarkerResult(Marker marker, string remainingText)
+        public ConvertToMarkerResult(Marker marker, ReadOnlySpan<char> remainingText)
         {
             this.marker = marker;
             this.remainingText = remainingText;
         }
-        public Marker marker;
-        public string remainingText;
+        public Marker marker { get; set; }
+        public ReadOnlySpan<char> remainingText { get; set; }
     }
 }

--- a/USFMToolsSharp/Models/Markers/ADDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/ADDMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class ADDMarker : Marker
     {
         public override string Identifier => "add";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic => new () {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/ADDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/ADDMarker.cs
@@ -14,7 +14,7 @@ namespace USFMToolsSharp.Models.Markers
         {
             return input.Trim();
         }
-        private static HashSet<Type> AllowedContentsStatic => new () {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new () {
             typeof(TextBlock),
         };
         public override HashSet<Type> AllowedContents => AllowedContentsStatic;

--- a/USFMToolsSharp/Models/Markers/BDITMarker.cs
+++ b/USFMToolsSharp/Models/Markers/BDITMarker.cs
@@ -14,7 +14,8 @@ namespace USFMToolsSharp.Models.Markers
         {
             return input.Trim();
         }
-        private static HashSet<Type> AllowedContentsStatic => new () { typeof(TextBlock) };
+        private static HashSet<Type> AllowedContentsStatic { get; } = [typeof(TextBlock)];
+
         public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/BDITMarker.cs
+++ b/USFMToolsSharp/Models/Markers/BDITMarker.cs
@@ -10,10 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class BDITMarker : Marker
     {
         public override string Identifier => "bdit";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() { typeof(TextBlock) };
+        private static HashSet<Type> AllowedContentsStatic => new () { typeof(TextBlock) };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/BDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/BDMarker.cs
@@ -14,13 +14,17 @@ namespace USFMToolsSharp.Models.Markers
         /// </summary>
         public string Text;
         public override string Identifier => "bd";
-        public override string PreProcess(string input)
+        
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+
+        private static HashSet<Type> AllowedTypesStatic = new()
         {
             typeof(TextBlock),
         };
+
+        public override HashSet<Type> AllowedContents => AllowedTypesStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/BKMarker.cs
+++ b/USFMToolsSharp/Models/Markers/BKMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string BookTitle;
         public override string Identifier => "bk";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            BookTitle = input.Trim();
-            return string.Empty;
+            BookTitle = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/CAMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CAMarker.cs
@@ -12,10 +12,11 @@ namespace USFMToolsSharp.Models.Markers
         public string AltChapterNumber;
 
         public override string Identifier => "ca";
-        public override string PreProcess(string input)
+        
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            AltChapterNumber = input.Trim();
-            return string.Empty;
+            AltChapterNumber = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/CDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CDMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string Description;
         public override string Identifier => "cd";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Description = input;
-            return string.Empty;
+            Description = input.ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/CLMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CLMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string Label;
         public override string Identifier => "cl";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Label = input.Trim();
-            return string.Empty;
+            Label = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/CLSMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CLSMarker.cs
@@ -10,13 +10,14 @@ namespace USFMToolsSharp.Models.Markers
     public class CLSMarker : Marker
     {
         public override string Identifier => "cls";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic => new ()
         {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/CLSMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CLSMarker.cs
@@ -14,7 +14,7 @@ namespace USFMToolsSharp.Models.Markers
         {
             return input.Trim();
         }
-        private static HashSet<Type> AllowedContentsStatic => new ()
+        private static HashSet<Type> AllowedContentsStatic  { get; } = new ()
         {
             typeof(TextBlock)
         };

--- a/USFMToolsSharp/Models/Markers/CMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CMarker.cs
@@ -8,9 +8,8 @@ namespace USFMToolsSharp.Models.Markers
     /// <summary>
     /// Chapter marker
     /// </summary>
-    public class CMarker : Marker
+    public partial class CMarker : Marker
     {
-        private static Regex regex = new Regex(" *(\\d*) *(.*)", RegexOptions.Singleline);
         public int Number;
         public string PublishedChapterMarker
         {
@@ -44,28 +43,31 @@ namespace USFMToolsSharp.Models.Markers
             }
         }
         public override string Identifier => "c";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            var match = regex.Match(input);
+            var match = GetChapterRegex().Match(input.ToString());
             if (match.Success)
             {
-                if (string.IsNullOrWhiteSpace(match.Groups[1].Value))
+                if (match.Groups[1].ValueSpan.Length == 0 || match.Groups[1].ValueSpan.IsWhiteSpace())
                 {
                     Number = 0;
                 }
                 else
                 {
-                    Number = int.Parse(match.Groups[1].Value);
+                    Number = int.Parse(match.Groups[1].ValueSpan);
                 }
-                if (string.IsNullOrWhiteSpace(match.Groups[2].Value))
+                if (match.Groups[2].ValueSpan.Length == 0 || match.Groups[2].ValueSpan.IsWhiteSpace())
                 {
                     return string.Empty;
                 }
-                return match.Groups[2].Value.TrimEnd();
+                return match.Groups[2].ValueSpan.TrimEnd();
             }
             return string.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
+
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(MMarker),
             typeof(MSMarker),
             typeof(SMarker),
@@ -101,5 +103,8 @@ namespace USFMToolsSharp.Models.Markers
             typeof(FMarker),
             typeof(FEndMarker),
         };
+
+        [GeneratedRegex(" *(\\d*) *(.*)", RegexOptions.Compiled | RegexOptions.Singleline)]
+        private static partial Regex GetChapterRegex();
     }
 }

--- a/USFMToolsSharp/Models/Markers/CMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CMarker.cs
@@ -8,8 +8,9 @@ namespace USFMToolsSharp.Models.Markers
     /// <summary>
     /// Chapter marker
     /// </summary>
-    public partial class CMarker : Marker
+    public class CMarker : Marker
     {
+        private static readonly System.Buffers.SearchValues<char> Numbers = System.Buffers.SearchValues.Create("0123456789");
         public int Number;
         public string PublishedChapterMarker
         {
@@ -45,7 +46,7 @@ namespace USFMToolsSharp.Models.Markers
         public override string Identifier => "c";
         public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            var startOfChapterNumber = input.IndexOfAny(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+            var startOfChapterNumber = input.IndexOfAny(Numbers);
             var foundChapterNumber = startOfChapterNumber != -1;
             if (!foundChapterNumber)
             {

--- a/USFMToolsSharp/Models/Markers/CMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CMarker.cs
@@ -58,11 +58,11 @@ namespace USFMToolsSharp.Models.Markers
                 }
                 if (match.Groups[2].ValueSpan.Length == 0 || match.Groups[2].ValueSpan.IsWhiteSpace())
                 {
-                    return string.Empty;
+                    return ReadOnlySpan<char>.Empty;
                 }
                 return match.Groups[2].ValueSpan.TrimEnd();
             }
-            return string.Empty;
+            return ReadOnlySpan<char>.Empty;
         }
 
         public override HashSet<Type> AllowedContents => AllowedContentsStatic;

--- a/USFMToolsSharp/Models/Markers/CMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CMarker.cs
@@ -45,24 +45,22 @@ namespace USFMToolsSharp.Models.Markers
         public override string Identifier => "c";
         public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            var match = GetChapterRegex().Match(input.ToString());
-            if (match.Success)
+            var startOfChapterNumber = input.IndexOfAny(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+            var foundChapterNumber = startOfChapterNumber != -1;
+            if (!foundChapterNumber)
             {
-                if (match.Groups[1].ValueSpan.Length == 0 || match.Groups[1].ValueSpan.IsWhiteSpace())
-                {
-                    Number = 0;
-                }
-                else
-                {
-                    Number = int.Parse(match.Groups[1].ValueSpan);
-                }
-                if (match.Groups[2].ValueSpan.Length == 0 || match.Groups[2].ValueSpan.IsWhiteSpace())
-                {
-                    return ReadOnlySpan<char>.Empty;
-                }
-                return match.Groups[2].ValueSpan.TrimEnd();
+                Number = 0;
+                return input.Trim();
             }
-            return ReadOnlySpan<char>.Empty;
+            var firstBlankAfterNumber = input[startOfChapterNumber..].IndexOf(' ') + startOfChapterNumber;
+            if (firstBlankAfterNumber <= 0)
+            {
+                firstBlankAfterNumber = input.Length;
+            }
+
+            Number = int.Parse(input[startOfChapterNumber..firstBlankAfterNumber]);
+
+            return input[firstBlankAfterNumber..].Trim();
         }
 
         public override HashSet<Type> AllowedContents => AllowedContentsStatic;
@@ -103,8 +101,5 @@ namespace USFMToolsSharp.Models.Markers
             typeof(FMarker),
             typeof(FEndMarker),
         };
-
-        [GeneratedRegex(" *(\\d*) *(.*)", RegexOptions.Compiled | RegexOptions.Singleline)]
-        private static partial Regex GetChapterRegex();
     }
 }

--- a/USFMToolsSharp/Models/Markers/CPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/CPMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string PublishedChapterMarker;
         public override string Identifier => "cp";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            PublishedChapterMarker = input.Trim();
-            return string.Empty;
+            PublishedChapterMarker = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/DMarker.cs
+++ b/USFMToolsSharp/Models/Markers/DMarker.cs
@@ -11,17 +11,19 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string Description;
         public override string Identifier => "d";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Description = input.Trim();
-            return string.Empty;
+            Description = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic => new () {
             typeof(FMarker),
             typeof(FEndMarker),
             typeof(ITMarker),
             typeof(ITEndMarker),
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
+        
     }
 }

--- a/USFMToolsSharp/Models/Markers/DMarker.cs
+++ b/USFMToolsSharp/Models/Markers/DMarker.cs
@@ -16,7 +16,7 @@ namespace USFMToolsSharp.Models.Markers
             Description = input.Trim().ToString();
             return ReadOnlySpan<char>.Empty;
         }
-        private static HashSet<Type> AllowedContentsStatic => new () {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new () {
             typeof(FMarker),
             typeof(FEndMarker),
             typeof(ITMarker),

--- a/USFMToolsSharp/Models/Markers/EMMarker.cs
+++ b/USFMToolsSharp/Models/Markers/EMMarker.cs
@@ -10,11 +10,12 @@ namespace USFMToolsSharp.Models.Markers
     public class EMMarker : Marker
     {
         public override string Identifier => "em";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() { typeof(TextBlock) };
+        private static HashSet<Type> AllowedContentsStatic => new () { typeof(TextBlock) };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/EMMarker.cs
+++ b/USFMToolsSharp/Models/Markers/EMMarker.cs
@@ -14,7 +14,7 @@ namespace USFMToolsSharp.Models.Markers
         {
             return input.Trim();
         }
-        private static HashSet<Type> AllowedContentsStatic => new () { typeof(TextBlock) };
+        private static HashSet<Type> AllowedContentsStatic { get; }  = new () { typeof(TextBlock) };
         public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }

--- a/USFMToolsSharp/Models/Markers/FIGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FIGMarker.cs
@@ -96,7 +96,7 @@ namespace USFMToolsSharp.Models.Markers
 
             
 
-            return string.Empty;
+            return ReadOnlySpan<char>.Empty;
             
         }
 

--- a/USFMToolsSharp/Models/Markers/FIGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FIGMarker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -20,11 +21,13 @@ namespace USFMToolsSharp.Models.Markers
 
         public override string Identifier => "fig";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
+            // TODO: This can probably be done with a span so we can come back to it later
             input = input.Trim();
+            var split = input.ToString().Split('|');
 
-            string[] wordEntry = input.Split('|');
+            string[] wordEntry = split;
             if (wordEntry.Length > 0)
             {
                 Description = wordEntry[0].Trim();
@@ -56,7 +59,7 @@ namespace USFMToolsSharp.Models.Markers
 
 
             
-            string[] contentArr = input.Split('|');
+            string[] contentArr = split;
             if (contentArr.Length > 0 && contentArr.Length <= 2)
             {
                 Caption = contentArr[0].Trim();

--- a/USFMToolsSharp/Models/Markers/FKMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FKMarker.cs
@@ -13,10 +13,10 @@ namespace USFMToolsSharp.Models.Markers
         public string FootNoteKeyword;
 
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            FootNoteKeyword = input.Trim();
-            return string.Empty;
+            FootNoteKeyword = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/FMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FMarker.cs
@@ -18,7 +18,7 @@ namespace USFMToolsSharp.Models.Markers
             FootNoteCaller = input.Trim().ToString();
             return ReadOnlySpan<char>.Empty;
         }
-        private static HashSet<Type> AllowedContentsStatic => new ()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new ()
         {
             typeof(FRMarker),
             typeof(FREndMarker),

--- a/USFMToolsSharp/Models/Markers/FMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FMarker.cs
@@ -13,12 +13,12 @@ namespace USFMToolsSharp.Models.Markers
         public string FootNoteCaller;
 
         
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            FootNoteCaller = input.Trim();
-            return string.Empty;
+            FootNoteCaller = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic => new ()
         {
             typeof(FRMarker),
             typeof(FREndMarker),
@@ -47,5 +47,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(BDMarker),
             typeof(BDEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/FPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FPMarker.cs
@@ -10,9 +10,10 @@ namespace USFMToolsSharp.Models.Markers
     public class FPMarker : Marker
     {
         public override string Identifier => "fp";
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic => new ()
         {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/FPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FPMarker.cs
@@ -10,7 +10,7 @@ namespace USFMToolsSharp.Models.Markers
     public class FPMarker : Marker
     {
         public override string Identifier => "fp";
-        private static HashSet<Type> AllowedContentsStatic => new ()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new ()
         {
             typeof(TextBlock),
         };

--- a/USFMToolsSharp/Models/Markers/FQAMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQAMarker.cs
@@ -11,12 +11,12 @@ namespace USFMToolsSharp.Models.Markers
     {
         public override string Identifier => "fqa";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
 
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(TLMarker),
@@ -24,5 +24,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WMarker),
             typeof(WEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/FQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FQMarker.cs
@@ -11,12 +11,12 @@ namespace USFMToolsSharp.Models.Markers
     {
         public override string Identifier => "fq";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
 
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(TLMarker),
@@ -24,5 +24,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WMarker),
             typeof(WEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/FRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FRMarker.cs
@@ -13,10 +13,10 @@ namespace USFMToolsSharp.Models.Markers
         public string VerseReference;
 
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            VerseReference = input.Trim();
-            return string.Empty;
+            VerseReference = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/FTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FTMarker.cs
@@ -7,11 +7,11 @@ namespace USFMToolsSharp.Models.Markers
     public class FTMarker : Marker
     {
         public override string Identifier => "ft";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TLMarker),
             typeof(TLEndMarker),
             typeof(WMarker),
@@ -28,5 +28,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(BDMarker),
             typeof(BDEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/FVMarker.cs
+++ b/USFMToolsSharp/Models/Markers/FVMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string VerseCharacter;
         public override string Identifier => "fv";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            VerseCharacter = input.Trim();
-            return string.Empty;
+            VerseCharacter = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/HMarker.cs
+++ b/USFMToolsSharp/Models/Markers/HMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public string HeaderText;
         public override string Identifier => "h";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            HeaderText = input.Trim();
-            return string.Empty;
+            HeaderText = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
         
     }

--- a/USFMToolsSharp/Models/Markers/IDEMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IDEMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public string Encoding;
         public override string Identifier => "ide";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Encoding = input.Trim();
-            return string.Empty;
+            Encoding = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/IDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IDMarker.cs
@@ -8,10 +8,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string TextIdentifier;
         public override string Identifier => "id";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            TextIdentifier = input.Trim();
-            return string.Empty;
+            TextIdentifier = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/ILIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/ILIMarker.cs
@@ -11,11 +11,11 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int Depth = 1;
         public override string Identifier => "ili";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        public override HashSet<Type> AllowedContents => new () {
             typeof(TextBlock)
         };
     }

--- a/USFMToolsSharp/Models/Markers/IMIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IMIMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IMIMarker : Marker
     {
         public override string Identifier => "imi";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -25,6 +25,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(ITEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IMMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IMMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IMMarker : Marker
     {
         public override string Identifier => "im";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -25,6 +25,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(ITEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IMQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IMQMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IMQMarker : Marker
     {
         public override string Identifier => "imq";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -25,6 +25,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(ITEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IMTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IMTMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public int Weight = 1;
         public string IntroTitle;
         public override string Identifier => "imt";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            IntroTitle = input.Trim();
-            return string.Empty;
+            IntroTitle = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/IOMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IOMarker.cs
@@ -11,10 +11,11 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int Depth = 1;
         public override string Identifier => "io";
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
             typeof(IORMarker),
             typeof(IOREndMarker)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/IORMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IORMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class IORMarker : Marker
     {
         public override string Identifier => "ior";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/IOTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IOTMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string Title;
         public override string Identifier => "iot";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Title = input.Trim();
-            return string.Empty;
+            Title = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/IPIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IPIMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IPIMarker : Marker
     {
         public override string Identifier => "ipi";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -35,6 +35,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(SUPEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IPMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IPMarker : Marker
     {
         public override string Identifier => "ip";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -37,6 +37,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(RQMarker),
             typeof(RQEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IPQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IPQMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IPQMarker : Marker
     {
         public override string Identifier => "ipq";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -35,6 +35,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(SUPEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IPRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IPRMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class IPRMarker : Marker
     {
         public override string Identifier => "ipr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(BKMarker),
@@ -35,6 +35,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(SUPEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/IQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/IQMarker.cs
@@ -12,12 +12,13 @@ namespace USFMToolsSharp.Models.Markers
         public int Depth = 1;
         public string Text;
         public override string Identifier => "iq";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/ISMarker.cs
+++ b/USFMToolsSharp/Models/Markers/ISMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public int Weight = 1;
         public string Heading;
         public override string Identifier => "is";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Heading = input.Trim();
-            return string.Empty;
+            Heading = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/ITMarker.cs
+++ b/USFMToolsSharp/Models/Markers/ITMarker.cs
@@ -10,10 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class ITMarker : Marker
     {
         public override string Identifier => "it";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() { typeof(TextBlock) };
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() { typeof(TextBlock) };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/KMarker.cs
+++ b/USFMToolsSharp/Models/Markers/KMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class KMarker : Marker
     {
         public override string Identifier => "k";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/LFMarker.cs
+++ b/USFMToolsSharp/Models/Markers/LFMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class LFMarker : Marker
     {
         public override string Identifier => "lf";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/LIKMarker.cs
+++ b/USFMToolsSharp/Models/Markers/LIKMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class LIKMarker : Marker
     {
         public override string Identifier => "lik";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/LIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/LIMarker.cs
@@ -11,13 +11,14 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int Depth = 1;
         public override string Identifier => "li";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(VMarker),
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/LITLMarker.cs
+++ b/USFMToolsSharp/Models/Markers/LITLMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class LITLMarker : Marker
     {
         public override string Identifier => "litl";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/LIVMarker.cs
+++ b/USFMToolsSharp/Models/Markers/LIVMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class LIVMarker : Marker
     {
         public override string Identifier => "liv";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/MIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/MIMarker.cs
@@ -10,7 +10,7 @@ namespace USFMToolsSharp.Models.Markers
     public class MIMarker : Marker
     {
         public override string Identifier => "mi";
-        private static HashSet<Type> AllowedContentsStatic => new ()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new ()
         {
             typeof(TextBlock),
             typeof(VMarker),

--- a/USFMToolsSharp/Models/Markers/MIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/MIMarker.cs
@@ -10,7 +10,7 @@ namespace USFMToolsSharp.Models.Markers
     public class MIMarker : Marker
     {
         public override string Identifier => "mi";
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic => new ()
         {
             typeof(TextBlock),
             typeof(VMarker),
@@ -32,5 +32,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(SUPEndMarker)
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/MMarker.cs
+++ b/USFMToolsSharp/Models/Markers/MMarker.cs
@@ -10,7 +10,7 @@ namespace USFMToolsSharp.Models.Markers
     public class MMarker : Marker
     {
         public override string Identifier => "m";
-        public override List<Type> AllowedContents => new List<Type>()
+        public override HashSet<Type> AllowedContents => new()
         {
             typeof(VMarker),
             typeof(TextBlock),

--- a/USFMToolsSharp/Models/Markers/MRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/MRMarker.cs
@@ -12,14 +12,15 @@ namespace USFMToolsSharp.Models.Markers
         public int Weight = 1;
         public string SectionReference;
         public override string Identifier => "mr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            SectionReference= input.TrimStart();
-            return string.Empty;
+            SectionReference= input.TrimStart().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(FMarker),
             typeof(FEndMarker)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/MSMarker.cs
+++ b/USFMToolsSharp/Models/Markers/MSMarker.cs
@@ -12,13 +12,14 @@ namespace USFMToolsSharp.Models.Markers
         public int Weight = 1; 
         public string Heading;
         public override string Identifier => "ms";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Heading = input.TrimStart();
-            return string.Empty;
+            Heading = input.TrimStart().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(MRMarker)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/MTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/MTMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public int Weight = 1;
         public string Title;
         public override string Identifier => "mt";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Title = input.Trim();
-            return string.Empty;
+            Title = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/Marker.cs
+++ b/USFMToolsSharp/Models/Markers/Marker.cs
@@ -197,9 +197,9 @@ namespace USFMToolsSharp.Models.Markers
             while (stack.Count > 0)
             {
                 var marker = stack.Pop();
-                if (marker is T)
+                if (marker is T castedMarker)
                 {
-                    output.Add((T)marker);
+                    output.Add(castedMarker);
                 }
                 foreach (var child in marker.Contents)
                 {

--- a/USFMToolsSharp/Models/Markers/Marker.cs
+++ b/USFMToolsSharp/Models/Markers/Marker.cs
@@ -14,18 +14,15 @@ namespace USFMToolsSharp.Models.Markers
         public List<Marker> Contents;
         public abstract string Identifier { get; }
         public int Position { get; set; }
-        public virtual List<Type> AllowedContents {
-            get {
-                return new List<Type>();
-            }
-        }
+        private static HashSet<Type> EmptyHashSet = new HashSet<Type>();
+        public virtual HashSet<Type> AllowedContents => EmptyHashSet;
 
         /// <summary>
         /// Pre-process the text contents before creating text elements inside of it
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        public virtual string PreProcess(string input)
+        public virtual ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input;
         }

--- a/USFMToolsSharp/Models/Markers/NDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/NDMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class NDMarker : Marker
     {
         public override string Identifier => "nd";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/NOMarker.cs
+++ b/USFMToolsSharp/Models/Markers/NOMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class NOMarker : Marker
     {
         public override string Identifier => "no";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/ORDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/ORDMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class ORDMarker : Marker
     {
         public override string Identifier => "ord";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PCMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PCMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class PCMarker : Marker
     {
         public override string Identifier => "pc";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(VMarker),
             typeof(BMarker),
@@ -26,5 +26,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(QMarker),
             typeof(SCMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PIMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PIMarker.cs
@@ -12,11 +12,11 @@ namespace USFMToolsSharp.Models.Markers
         public int Depth = 1;
         public override string Identifier => "pi";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(VMarker),
             typeof(BMarker),
             typeof(SPMarker),
@@ -26,5 +26,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(LIMarker),
             typeof(QMarker)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PMCMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PMCMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class PMCMarker : Marker
     {
         public override string Identifier => "pmc";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PMOMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PMOMarker.cs
@@ -7,12 +7,14 @@ namespace USFMToolsSharp.Models.Markers
     public class PMOMarker : Marker
     {
         public override string Identifier => "pmo";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PMRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PMRMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class PMRMarker : Marker
     {
         public override string Identifier => "pmr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PMarker.cs
@@ -7,11 +7,14 @@ namespace USFMToolsSharp.Models.Markers
     public class PMarker : Marker
     {
         public override string Identifier => "p";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
+
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(VMarker),
             typeof(BMarker),
             typeof(SPMarker),

--- a/USFMToolsSharp/Models/Markers/PNGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PNGMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class PNGMarker : Marker
     {
         public override string Identifier => "png";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PNMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PNMarker.cs
@@ -11,12 +11,13 @@ namespace USFMToolsSharp.Models.Markers
     public class PNMarker : Marker
     {
         public override string Identifier => "pn";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PRMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class PRMarker : Marker
     {
         public override string Identifier => "pr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/PROMarker.cs
+++ b/USFMToolsSharp/Models/Markers/PROMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class PROMarker : Marker
     {
         public override string Identifier => "pro";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/QACMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QACMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string AcrosticLetter;
         public override string Identifier => "qac";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            AcrosticLetter = input.Trim();
-            return string.Empty;
+            AcrosticLetter = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/QAMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QAMarker.cs
@@ -14,14 +14,15 @@ namespace USFMToolsSharp.Models.Markers
         /// </summary>
         public string Heading;
         public override string Identifier => "qa";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Heading = input.Trim();
-            return string.Empty;
+            Heading = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(QACMarker),
             typeof(QACEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/QCMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QCMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class QCMarker : Marker
     {
         public override string Identifier => "qc";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(FMarker),
@@ -25,6 +25,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WEndMarker),
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
 
     }

--- a/USFMToolsSharp/Models/Markers/QDMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QDMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class QDMarker : Marker
     {
         public override string Identifier => "qd";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(FMarker),
@@ -24,5 +24,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WMarker),
             typeof(WEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/QMMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QMMarker.cs
@@ -11,11 +11,11 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int Depth = 1;
         public override string Identifier => "qm";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(FMarker),
@@ -25,5 +25,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WMarker),
             typeof(WEndMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/QMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QMarker.cs
@@ -14,11 +14,11 @@ namespace USFMToolsSharp.Models.Markers
         public string Text;
         public bool IsPoetryBlock;
         public override string Identifier => "q";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(BMarker),
             typeof(QSMarker),
             typeof(QSEndMarker),
@@ -31,6 +31,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WEndMarker),
             typeof(VMarker),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
         public override bool TryInsert(Marker input)
         {

--- a/USFMToolsSharp/Models/Markers/QRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QRMarker.cs
@@ -10,11 +10,11 @@ namespace USFMToolsSharp.Models.Markers
     public class QRMarker : Marker
     {
         public override string Identifier => "qr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock),
             typeof(FMarker),
@@ -25,6 +25,7 @@ namespace USFMToolsSharp.Models.Markers
             typeof(WEndMarker),
 
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
         
             
     }

--- a/USFMToolsSharp/Models/Markers/QSMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QSMarker.cs
@@ -11,12 +11,13 @@ namespace USFMToolsSharp.Models.Markers
     {
         public String Text;
         public override string Identifier => "qs";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/QTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/QTMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class QTMarker : Marker
     {
         public override string Identifier => "qt";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/RBMarker.cs
+++ b/USFMToolsSharp/Models/Markers/RBMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class RBMarker : Marker
     {
         public override string Identifier => "rb";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/REMMarker.cs
+++ b/USFMToolsSharp/Models/Markers/REMMarker.cs
@@ -9,10 +9,10 @@ namespace USFMToolsSharp.Models.Markers
         public string Comment;
         public override string Identifier => "rem";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Comment = input.Trim();
-            return string.Empty;
+            Comment = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/RMarker.cs
+++ b/USFMToolsSharp/Models/Markers/RMarker.cs
@@ -10,13 +10,14 @@ namespace USFMToolsSharp.Models.Markers
     public class RMarker : Marker
     {
         public override string Identifier => "r";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
 
     }
 }

--- a/USFMToolsSharp/Models/Markers/RQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/RQMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class RQMarker : Marker
     {
         public override string Identifier => "rq";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/SCMarker.cs
+++ b/USFMToolsSharp/Models/Markers/SCMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class SCMarker : Marker
     {
         public override string Identifier => "sc";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/SIGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/SIGMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class SIGMarker : Marker
     {
         public override string Identifier => "sig";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/SLSMarker.cs
+++ b/USFMToolsSharp/Models/Markers/SLSMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class SLSMarker : Marker
     {
         public override string Identifier => "sls";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/SMarker.cs
+++ b/USFMToolsSharp/Models/Markers/SMarker.cs
@@ -12,12 +12,12 @@ namespace USFMToolsSharp.Models.Markers
         public int Weight = 1;
         public string Text;
         public override string Identifier => "s";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Text = input.TrimStart();
-            return string.Empty;
+            Text = input.TrimStart().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(RMarker),
             typeof(FMarker),
             typeof(FEndMarker),
@@ -37,5 +37,6 @@ namespace USFMToolsSharp.Models.Markers
             typeof(SUPEndMarker),
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/SPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/SPMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string Speaker;
         public override string Identifier => "sp";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Speaker = input.Trim();
-            return string.Empty;
+            Speaker = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/STSMarker.cs
+++ b/USFMToolsSharp/Models/Markers/STSMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string StatusText;
         public override string Identifier => "sts";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            StatusText = input.Trim();
-            return string.Empty;
+            StatusText = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/SUPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/SUPMarker.cs
@@ -11,12 +11,13 @@ namespace USFMToolsSharp.Models.Markers
     {
         public override string Identifier => "sup";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/TCMarker.cs
+++ b/USFMToolsSharp/Models/Markers/TCMarker.cs
@@ -11,13 +11,14 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int ColumnPosition = 1;
         public override string Identifier => "tc";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
 
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/TCRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/TCRMarker.cs
@@ -11,12 +11,13 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int ColumnPosition = 1;
         public override string Identifier => "tcr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/THMarker.cs
+++ b/USFMToolsSharp/Models/Markers/THMarker.cs
@@ -11,12 +11,13 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int ColumnPosition = 1;
         public override string Identifier => "th";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/THRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/THRMarker.cs
@@ -11,12 +11,13 @@ namespace USFMToolsSharp.Models.Markers
     {
         public int ColumnPosition = 1;
         public override string Identifier => "thr";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/TLMarker.cs
+++ b/USFMToolsSharp/Models/Markers/TLMarker.cs
@@ -10,13 +10,14 @@ namespace USFMToolsSharp.Models.Markers
     public class TLMarker : Marker
     {
         public override string Identifier => "tl";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/TOC1Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOC1Marker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string LongTableOfContentsText;
         public override string Identifier => "toc1";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            LongTableOfContentsText = input.Trim();
-            return string.Empty;
+            LongTableOfContentsText = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/TOC2Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOC2Marker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string ShortTableOfContentsText;
         public override string Identifier => "toc2";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            ShortTableOfContentsText = input.Trim();
-            return string.Empty;
+            ShortTableOfContentsText = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/TOC3Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOC3Marker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string BookAbbreviation;
         public override string Identifier => "toc3";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            BookAbbreviation = input.Trim();
-            return string.Empty;
+            BookAbbreviation = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/TOCA1Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOCA1Marker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string AltLongTableOfContentsText;
         public override string Identifier => "toca1";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            AltLongTableOfContentsText = input.Trim();
-            return string.Empty;
+            AltLongTableOfContentsText = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/TOCA2Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOCA2Marker.cs
@@ -11,9 +11,9 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string AltShortTableOfContentsText;
         public override string Identifier => "toca2";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            AltShortTableOfContentsText = input.Trim();
+            AltShortTableOfContentsText = input.Trim().ToString();
             return string.Empty;
         }
     }

--- a/USFMToolsSharp/Models/Markers/TOCA2Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOCA2Marker.cs
@@ -14,7 +14,7 @@ namespace USFMToolsSharp.Models.Markers
         public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             AltShortTableOfContentsText = input.Trim().ToString();
-            return string.Empty;
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/TOCA3Marker.cs
+++ b/USFMToolsSharp/Models/Markers/TOCA3Marker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string AltBookAbbreviation;
         public override string Identifier => "toca3";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            AltBookAbbreviation = input.Trim();
-            return string.Empty;
+            AltBookAbbreviation = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/TRMarker.cs
+++ b/USFMToolsSharp/Models/Markers/TRMarker.cs
@@ -11,11 +11,12 @@ namespace USFMToolsSharp.Models.Markers
     {
         public override string Identifier => "tr";
 
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TCMarker),
             typeof(THMarker),
             typeof(TCRMarker),
             typeof(THRMarker)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/TableBlock.cs
+++ b/USFMToolsSharp/Models/Markers/TableBlock.cs
@@ -11,9 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public override string Identifier => string.Empty;
 
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(TRMarker)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/USFMDocument.cs
+++ b/USFMToolsSharp/Models/Markers/USFMDocument.cs
@@ -11,7 +11,7 @@ namespace USFMToolsSharp.Models.Markers
             Contents = new List<Marker>();
         }
 
-        public override string Identifier => "";
+        public override string Identifier => string.Empty;
 
 
         public override HashSet<Type> AllowedContents => AllowedContentsStatic;

--- a/USFMToolsSharp/Models/Markers/USFMDocument.cs
+++ b/USFMToolsSharp/Models/Markers/USFMDocument.cs
@@ -13,42 +13,40 @@ namespace USFMToolsSharp.Models.Markers
 
         public override string Identifier => "";
 
-        public override List<Type> AllowedContents
-        {
-            get
-            {
-                return new List<Type>(){
-                    typeof(HMarker),
-                    typeof(IDEMarker),
-                    typeof(IDMarker),
-                    typeof(IBMarker),
-                    typeof(IQMarker),
-                    typeof(ILIMarker),
-                    typeof(IOTMarker),
-                    typeof(IOMarker),
-                    typeof(STSMarker),
-                    typeof(USFMMarker),
-                    typeof(TOC1Marker),
-                    typeof(TOC2Marker),
-                    typeof(TOC3Marker),
-                    typeof(TOCA1Marker),
-                    typeof(TOCA2Marker),
-                    typeof(TOCA3Marker),
-                    typeof(ISMarker),
-                    typeof(MTMarker),
-                    typeof(IMTMarker),
-                    typeof(IPMarker),
-                    typeof(IPIMarker),
-                    typeof(IMMarker),
-                    typeof(IMIMarker),
-                    typeof(IPQMarker),
-                    typeof(IMQMarker),
-                    typeof(IPRMarker),
-                    typeof(CLMarker),
-                    typeof(CMarker)
-                };
-            }
-        }
+
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
+        private static HashSet<Type> AllowedContentsStatic { get; } =
+            new(){
+                typeof(HMarker),
+                typeof(IDEMarker),
+                typeof(IDMarker),
+                typeof(IBMarker),
+                typeof(IQMarker),
+                typeof(ILIMarker),
+                typeof(IOTMarker),
+                typeof(IOMarker),
+                typeof(STSMarker),
+                typeof(USFMMarker),
+                typeof(TOC1Marker),
+                typeof(TOC2Marker),
+                typeof(TOC3Marker),
+                typeof(TOCA1Marker),
+                typeof(TOCA2Marker),
+                typeof(TOCA3Marker),
+                typeof(ISMarker),
+                typeof(MTMarker),
+                typeof(IMTMarker),
+                typeof(IPMarker),
+                typeof(IPIMarker),
+                typeof(IMMarker),
+                typeof(IMIMarker),
+                typeof(IPQMarker),
+                typeof(IMQMarker),
+                typeof(IPRMarker),
+                typeof(CLMarker),
+                typeof(CMarker)
+            };
+
         public void Insert(Marker input)
         {
             if (!TryInsert(input))

--- a/USFMToolsSharp/Models/Markers/USFMMarker.cs
+++ b/USFMToolsSharp/Models/Markers/USFMMarker.cs
@@ -16,10 +16,10 @@ namespace USFMToolsSharp.Models.Markers
         /// </summary>
         public string Version { get; set; }
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            Version = input.Trim();
-            return string.Empty;
+            Version = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/UnknownMarker.cs
+++ b/USFMToolsSharp/Models/Markers/UnknownMarker.cs
@@ -10,10 +10,10 @@ namespace USFMToolsSharp.Models.Markers
         public string ParsedValue;
 
         public override string Identifier => string.Empty;
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            ParsedValue = input;
-            return string.Empty;
+            ParsedValue = input.ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/VAMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VAMarker.cs
@@ -12,10 +12,10 @@ namespace USFMToolsSharp.Models.Markers
         public string AltVerseNumber;
         
         public override string Identifier => "va";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            AltVerseNumber = input.Trim();
-            return string.Empty;
+            AltVerseNumber = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/VMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VMarker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace USFMToolsSharp.Models.Markers
@@ -28,14 +27,15 @@ namespace USFMToolsSharp.Models.Markers
         public override string Identifier => "v";
         public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            // TODO: This could be done with spans
-            Match match = CreateRegex().Match(input.ToString());
-            VerseNumber = match.Groups[1].Value;
+            var match = CreateRegex().Match(input.ToString());
+            var verseNumberSpan = match.Groups[1].ValueSpan;
+            VerseNumber = verseNumberSpan.ToString();
             if (!string.IsNullOrWhiteSpace(VerseNumber))
             {
-                var verseBridgeChars = VerseNumber.Split('-');
-                StartingVerse = int.Parse(verseBridgeChars[0]);
-                EndingVerse = verseBridgeChars.Length > 1 && !string.IsNullOrWhiteSpace(verseBridgeChars[1]) ? int.Parse(verseBridgeChars[1]) : StartingVerse;
+                var index = verseNumberSpan.IndexOf('-');
+                var isBridge = index != -1;
+                StartingVerse = int.Parse(isBridge ? verseNumberSpan[..index]: verseNumberSpan);
+                EndingVerse = isBridge && !verseNumberSpan[index..].IsWhiteSpace() ? int.Parse(verseNumberSpan[(index + 1)..]) : StartingVerse;
             }
             return match.Groups[2].ValueSpan;
         }

--- a/USFMToolsSharp/Models/Markers/VPMarker.cs
+++ b/USFMToolsSharp/Models/Markers/VPMarker.cs
@@ -11,10 +11,10 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string VerseCharacter;
         public override string Identifier => "vp";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            VerseCharacter = input.Trim();
-            return string.Empty;
+            VerseCharacter = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
     }
 }

--- a/USFMToolsSharp/Models/Markers/WAMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WAMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class WAMarker : Marker
     {
         public override string Identifier => "wa";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/WGMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WGMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class WGMarker : Marker
     {
         public override string Identifier => "wg";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/WHMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WHMarker.cs
@@ -7,12 +7,14 @@ namespace USFMToolsSharp.Models.Markers
     public class WHMarker : Marker
     {
         public override string Identifier => "wh";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
+    
 }

--- a/USFMToolsSharp/Models/Markers/WJMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WJMarker.cs
@@ -7,12 +7,13 @@ namespace USFMToolsSharp.Models.Markers
     public class WJMarker : Marker
     {
         public override string Identifier => "wj";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock)
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/WMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WMarker.cs
@@ -19,7 +19,6 @@ namespace USFMToolsSharp.Models.Markers
             input = input.Trim();
             Attributes = new Dictionary<string, string>();
 
-            // TODO: This could probably be spans too
             string[] wordEntry = input.ToString().Split('|');
             Term = wordEntry[0];
 

--- a/USFMToolsSharp/Models/Markers/WMarker.cs
+++ b/USFMToolsSharp/Models/Markers/WMarker.cs
@@ -8,29 +8,28 @@ namespace USFMToolsSharp.Models.Markers
     /// <summary>
     /// Wordlist / Glossary / Dictionary Entry Marker
     /// </summary>
-    public class WMarker : Marker
+    public partial class WMarker : Marker
     {
         public string Term;
         public Dictionary<string, string> Attributes;
-        private static Regex wordAttrPattern = new Regex("([\\w-]+)=?\"?([\\w,:.]*)\"?", RegexOptions.Singleline);
         public override string Identifier => "w";
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             input = input.Trim();
             Attributes = new Dictionary<string, string>();
 
-            string[] wordEntry = input.Split('|');
+            // TODO: This could probably be spans too
+            string[] wordEntry = input.ToString().Split('|');
             Term = wordEntry[0];
 
             if (wordEntry.Length > 1)
             {
-
                 string[] wordAttr = wordEntry[1].Split(' ');
                 foreach (string attr in wordAttr)
                 {
-                    Match attrMatch = wordAttrPattern.Match(attr);
-                    if (attrMatch.Groups[2].Value.Length == 0)
+                    Match attrMatch = GetWordRegex().Match(attr);
+                    if (attrMatch.Groups[2].ValueSpan.Length == 0)
                     {
                         Attributes["lemma"] = attrMatch.Groups[1].Value;
                     }
@@ -43,8 +42,10 @@ namespace USFMToolsSharp.Models.Markers
 
             }
 
-            return string.Empty;
+            return ReadOnlySpan<char>.Empty;
         }
 
+        [GeneratedRegex("([\\w-]+)=?\"?([\\w,:.]*)\"?", RegexOptions.Compiled | RegexOptions.Singleline)]
+        private static partial Regex GetWordRegex();
     }
 }

--- a/USFMToolsSharp/Models/Markers/XMarker.cs
+++ b/USFMToolsSharp/Models/Markers/XMarker.cs
@@ -12,17 +12,18 @@ namespace USFMToolsSharp.Models.Markers
         public override string Identifier => "x";
         public string CrossRefCaller;
 
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            CrossRefCaller = input.Trim();
-            return string.Empty;
+            CrossRefCaller = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>()
+        private static HashSet<Type> AllowedContentsStatic { get; } = new()
         {
             typeof(XOMarker),
             typeof(XTMarker),
             typeof(XQMarker),
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/XOMarker.cs
+++ b/USFMToolsSharp/Models/Markers/XOMarker.cs
@@ -11,13 +11,14 @@ namespace USFMToolsSharp.Models.Markers
     {
         public string OriginRef;
         public override string Identifier => "xo";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
-            OriginRef = input.Trim();
-            return string.Empty;
+            OriginRef = input.Trim().ToString();
+            return ReadOnlySpan<char>.Empty;
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/XQMarker.cs
+++ b/USFMToolsSharp/Models/Markers/XQMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class XQMarker : Marker
     {
         public override string Identifier => "xq";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.Trim();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/Models/Markers/XTMarker.cs
+++ b/USFMToolsSharp/Models/Markers/XTMarker.cs
@@ -10,12 +10,13 @@ namespace USFMToolsSharp.Models.Markers
     public class XTMarker : Marker
     {
         public override string Identifier => "xt";
-        public override string PreProcess(string input)
+        public override ReadOnlySpan<char> PreProcess(ReadOnlySpan<char> input)
         {
             return input.TrimStart();
         }
-        public override List<Type> AllowedContents => new List<Type>() {
+        private static HashSet<Type> AllowedContentsStatic { get; } = new() {
             typeof(TextBlock),
         };
+        public override HashSet<Type> AllowedContents => AllowedContentsStatic;
     }
 }

--- a/USFMToolsSharp/USFMParser.cs
+++ b/USFMToolsSharp/USFMParser.cs
@@ -170,7 +170,7 @@ namespace USFMToolsSharp
             else if (inContent)
             {
                 endOfContent = index;
-                // Handle content here
+                // Handle marker with content
                 AddMarkerToList(input[startOfMarker ..endOfMarker], startOfContent == endOfContent ? ReadOnlySpan<char>.Empty : input[startOfContent..endOfContent], startOfMarker, output);
             }
 

--- a/USFMToolsSharp/USFMToolsSharp.csproj
+++ b/USFMToolsSharp/USFMToolsSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageProjectUrl>https://github.com/WycliffeAssociates/USFMToolsSharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/WycliffeAssociates/USFMToolsSharp</RepositoryUrl>
     <Copyright />
@@ -13,7 +13,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Description>A parsing library for USFM</Description>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -290,6 +290,9 @@ namespace USFMToolsSharpTest
             // Transliterated
             Assert.AreEqual("Hades", ((TextBlock)parser.ParseFromString("\\f + \\fr 10:15 \\fk dunia orang mati \\ft Dalam bahasa Yunani adalah \\tl Hades\\tl* \\ft , tempat orang setelah meninggal.\\f*").Contents[0].Contents[2].Contents[1].Contents[0]).Text);
             Assert.AreEqual("TEKEL", ((TextBlock)parser.ParseFromString("\\v 27 \\tl TEKEL\\tl* :").Contents[0].Contents[0].Contents[0]).Text);
+            // Test with newline after the verse number
+            Assert.AreEqual("1", ((VMarker)parser.ParseFromString("\\v 1\n").Contents[0]).VerseNumber);
+            Assert.AreEqual("1", ((VMarker)parser.ParseFromString("\\v 1\"").Contents[0]).VerseNumber);
         }
         [TestMethod]
         public void TestTableParse()

--- a/USFMToolsSharpTest/USFMParserTest.cs
+++ b/USFMToolsSharpTest/USFMParserTest.cs
@@ -273,6 +273,8 @@ namespace USFMToolsSharpTest
             Assert.AreEqual("26", ((VMarker)(parser.ParseFromString("\\v 26 God said, \"Let us make man in our image, after our likeness. Let them have dominion over the fish of the sea, over the birds of the sky, over the livestock, over all the earth, and over every creeping thing that creeps on the earth.\" \\f + \\ft Some ancient copies have: \\fqa ... Over the livestock, over all the animals of the earth, and over every creeping thing that creeps on the earth \\fqa*  . \\f*").Contents[0])).VerseNumber);
             Assert.AreEqual("0", ((VMarker)parser.ParseFromString("\\v 0 Not in the Bible").Contents[0]).VerseNumber);
             Assert.AreEqual("1-2", ((VMarker)parser.ParseFromString("\\v 1-2 Not in the Bible").Contents[0]).VerseNumber);
+            Assert.AreEqual(1, ((VMarker)parser.ParseFromString("\\v 1-2 Not in the Bible").Contents[0]).StartingVerse);
+            Assert.AreEqual(2, ((VMarker)parser.ParseFromString("\\v 1-2 Not in the Bible").Contents[0]).EndingVerse);
 
             // References - Quoted book title - Parallel passage reference
             Assert.AreEqual("(Luk. 3:23 - 38)", ((TextBlock)parser.ParseFromString("\\s Silsilah Yesus Kristus \\r (Luk. 3:23 - 38)").Contents[0].Contents[0].Contents[0]).Text);

--- a/USFMToolsSharpTest/USFMToolsSharpTest.csproj
+++ b/USFMToolsSharpTest/USFMToolsSharpTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This contains the following major changes:
- Moving to .net 8 and away from .net standard
- Move AllowedContents from a List that gets created on every Marker instance to a static HashSet
- Move to using Spans in a lot of places to cut down on GC pressure
- Moved from using Regex in the main tokenization to using a hand crafted iterator
- Moved several markers away from regex into hand crafted logic